### PR TITLE
Fix test so it will pass with recent versions of Mojolicious

### DIFF
--- a/t/010-tplugun.t
+++ b/t/010-tplugun.t
@@ -111,7 +111,7 @@ package MpemTest::Ctl;
 use Mojo::Base 'Mojolicious::Controller';
 
 sub hello {
-     $_[0]->render_text('Hello');
+     $_[0]->render(text => 'Hello');
 }
 
 sub crash {


### PR DESCRIPTION
I don't know if the interface for Mojolicious changed at some point, but now there is no method called render_text().  Instead, there is render(text => '...')
