### PR TITLE
Escape directory name in test regex

### DIFF
--- a/t/020-maildir.t
+++ b/t/020-maildir.t
@@ -52,7 +52,7 @@ $t->get_ok('/crash')
 
 my ($mail) = glob "$dir/*";
 
-like $mail, qr{^$dir/\d+\.\d+$}, 'file created';
+like $mail, qr{^\Q$dir\E[\\/]\d+\.\d+$}, 'file created';
 my $fh;
 ok open($fh, '<:raw', $mail), 'file opened';
 my $data = do { local $/; <$fh> };


### PR DESCRIPTION
The tests may fail on certain operating systems (e.g. Windows), if the directory name contains backslashes. This will prevent the directory name to be interpreted.