### PR TITLE
respect newline error messages

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,6 @@ WriteMakefile(
     VERSION_FROM      => 'lib/Mojolicious/Plugin/MailException.pm',
     PREREQ_PM         => {
         'Mojolicious'   => 0,
-        'MIME::Words'   => 0,
         'MIME::Lite'    => 0,
     },
     ($] >= 5.005 ? 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+libmojolicious-plugin-mailexception-perl (0.25-1) unstable; urgency=medium
+
+  * If the exception does not contain line and package name, do not
+    upgrade it to a Mojo::Exception and do not append line and package
+    name, thus respecting string exceptions ending with a newline.
+
+ -- Datensegler e.U. <operations@datensegler.at> Mon, 23 Aug 2021 15:00:00 +0200
+
 libmojolicious-plugin-mailexception-perl (0.24-1) unstable; urgency=medium
 
   * Do not croak if maildir is not accessible.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libmojolicious-plugin-mailexception-perl (0.26-1) unstable; urgency=medium
+
+  * let sender handle encodings.
+
+ -- Datensegler e.U. <operations@datensegler.at> Wed, 28 Mar 2023 15:19:00 +0200
+
 libmojolicious-plugin-mailexception-perl (0.25-1) unstable; urgency=medium
 
   * If the exception does not contain line and package name, do not

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libmojolicious-plugin-mailexception-perl (0.27-1) unstable; urgency=medium
+
+  * handle exceptions with trailing newline properly.
+
+ -- Datensegler e.U. <operations@datensegler.at> Fri, 24 Apr 2026 13:59:00 +0200
+
 libmojolicious-plugin-mailexception-perl (0.26-1) unstable; urgency=medium
 
   * let sender handle encodings.

--- a/lib/Mojolicious/Plugin/MailException.pm
+++ b/lib/Mojolicious/Plugin/MailException.pm
@@ -106,7 +106,7 @@ at your option, any later version of Perl 5 you may have available.
 
 package Mojolicious::Plugin::MailException;
 
-our $VERSION = '0.24';
+our $VERSION = '0.25';
 use 5.008008;
 use strict;
 use warnings;
@@ -271,18 +271,17 @@ sub register {
                 ($e) = @_;
 
                 unless (ref $e and $e->isa('Mojo::Exception')) {
-                    my @caller = caller;
+                    if ($e =~ s/at\s+(.+?)\s+line\s+(\d+).*//s) {
+                        my @caller = caller;
 
-                    $e =~ s/at\s+(.+?)\s+line\s+(\d+).*//s;
+                        $e = Mojo::Exception->new(
+                            sprintf "%s at %s line %d\n", "$e", @caller[1,2]
+                        );
 
-                    $e = Mojo::Exception->new(
-                        sprintf "%s at %s line %d\n", "$e", @caller[1,2]
-                    );
-                    $e->trace(1);
-                    $e->inspect if $e->can('inspect');
+                        $e->trace(1);
+                        $e->inspect if $e->can('inspect');
+                    }
                 }
-
-
                 CORE::die $e;
             };
 

--- a/lib/Mojolicious/Plugin/MailException.pm
+++ b/lib/Mojolicious/Plugin/MailException.pm
@@ -106,7 +106,7 @@ at your option, any later version of Perl 5 you may have available.
 
 package Mojolicious::Plugin::MailException;
 
-our $VERSION = '0.25';
+our $VERSION = '0.26';
 use 5.008008;
 use strict;
 use warnings;
@@ -116,7 +116,6 @@ use Data::Dumper;
 use Mojo::Exception;
 use Carp;
 use MIME::Lite;
-use MIME::Words ':all';
 use File::Spec::Functions 'rel2abs', 'catfile';
 
 
@@ -125,14 +124,10 @@ my $mail_prepare = sub {
     my $subject = $conf->{subject} || 'Caught exception';
     $subject .= ' (' . $self->req->method . ': ' .
         $self->req->url->to_abs->to_string . ')';
-    utf8::encode($subject) if utf8::is_utf8 $subject;
-    $subject = encode_mimeword $subject, 'B', 'utf-8';
-
 
     my $text = '';
     $text .= "Exception\n";
     $text .= "~~~~~~~~~\n";
-
 
     $text .= $e->message;
     $text .= "\n";
@@ -172,9 +167,6 @@ my $mail_prepare = sub {
         $text .= Dumper($self->session);
     }
 
-    eval { utf8::encode($text) if utf8::is_utf8 $text };
-
-
     my $mail = MIME::Lite->new(
         From    => $from,
         To      => $to,
@@ -184,7 +176,7 @@ my $mail_prepare = sub {
 
 
     $mail->attach(
-        Type    => 'text/plain; charset=utf-8',
+        Type    => 'text/plain',
         Data    => $text
     );
 
@@ -195,7 +187,7 @@ my $mail_prepare = sub {
     $text .= $req;
 
     $mail->attach(
-        Type        => 'text/plain; charset=utf-8',
+        Type        => 'text/plain',
         Filename    => 'request.txt',
         Disposition => 'inline',
         Data        => $text

--- a/lib/Mojolicious/Plugin/MailException.pm
+++ b/lib/Mojolicious/Plugin/MailException.pm
@@ -106,7 +106,7 @@ at your option, any later version of Perl 5 you may have available.
 
 package Mojolicious::Plugin::MailException;
 
-our $VERSION = '0.26';
+our $VERSION = '0.27';
 use 5.008008;
 use strict;
 use warnings;
@@ -234,7 +234,7 @@ sub register {
     my $stack_depth = $conf->{stack} || 20;
 
     my $cb = $conf->{send};
-    
+
     unless ('CODE' eq ref $cb) {
         $cb = sub { $_[0]->send };
         if (my $dir = $conf->{maildir}) {
@@ -263,16 +263,16 @@ sub register {
                 ($e) = @_;
 
                 unless (ref $e and $e->isa('Mojo::Exception')) {
-                    if ($e =~ s/at\s+(.+?)\s+line\s+(\d+).*//s) {
-                        my @caller = caller;
+                    my @caller = caller;
 
-                        $e = Mojo::Exception->new(
-                            sprintf "%s at %s line %d\n", "$e", @caller[1,2]
-                        );
+                    $e = Mojo::Exception->new(
+                        $e =~ /at\s+(.+?)\s+line\s+(\d+)/
+                            ? "$e"
+                            : sprintf "%s at %s line %d\n", "$e", @caller[1,2]
+                    );
 
-                        $e->trace(1);
-                        $e->inspect if $e->can('inspect');
-                    }
+                    $e->trace(1);
+                    $e->inspect if $e->can('inspect');
                 }
                 CORE::die $e;
             };


### PR DESCRIPTION
Problem:

String-exceptions (with newlines) getting manipulated which leads to problems when checking them or passing them through.


Our fix:

If the exception does not contain line and package name, do not upgrade it to a Mojo::Exception and do not append line and package name, thus respecting string exceptions ending with a newline.
